### PR TITLE
fix undefined method name

### DIFF
--- a/src/Wplang.php
+++ b/src/Wplang.php
@@ -77,7 +77,11 @@ class Wplang implements PluginInterface, EventSubscriberInterface {
 	 * @param  PackageEvent $event The package event object.
 	 */
 	public function onPackageAction( PackageEvent $event ) {
-		$package = $event->getOperation()->getPackage();
+        if ($event->getOperation()->getJobType() == 'update') {
+            $package = $event->getOperation()->getTargetPackage();
+        } else {
+            $package = $event->getOperation()->getPackage();
+        }
 		$this->getTranslations( $package );
 	}
 


### PR DESCRIPTION
In my project, no language packages are updated after Composer update action. Instead, the following error is output:

Fatal error: Uncaught Error: Call to undefined method Composer\DependencyResolver\Operation\UpdateOperation::getPackage() in phar:///www/htdocs/bin/composer.phar/src/Composer/Plugin/PluginManager.php(195) : eval()'d code:80
Stack trace:
#0 [internal function]: BJ\Wplang\Wplang_composer_tmp0->onPackageAction(Object(Composer\Installer\PackageEvent))
#1 phar:///www/htdocs/bin/composer.phar/src/Composer/EventDispatcher/EventDispatcher.php(176): call_user_func(Array, Object(Composer\Installer\PackageEvent))
#2 phar:///www/htdocs/bin/composer.phar/src/Composer/EventDispatcher/EventDispatcher.php(116): Composer\EventDispatcher\EventDispatcher->doDispatch(Object(Composer\Installer\PackageEvent))
#3 phar:///www/htdocs/bin/composer.phar/src/Composer/Installer.php(620): Composer\EventDispatcher\EventDispatcher->dispatchPackageEvent('post-package-up...', true, Object(Composer\DependencyResolver\DefaultPolicy), Object(Composer\DependencyResolver\Pool), Object(Composer\Repository\CompositeRepository) in phar:///www/htdocs/bin/composer.phar/src/Composer/Plugin/PluginManager.php(195) : eval()'d code on line 80

My installed version of Composer is 1.8.4.