### PR TITLE
Composer 2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -60,7 +60,7 @@ class Translatable {
 	 * @param string $type          The package type: 'plugin', 'theme' or 'core'.
 	 * @param string $slug          The plugin/theme slug, E.g. 'query-monitor'. In case of core, this is 'wordpress'.
 	 * @param string $version       The package version.
-	 * @param string $languages     Array of the languages we are using.
+	 * @param array $languages     Array of the languages we are using.
 	 * @param string $wpLanguageDir Full path to the language files target directory.
 	 */
 	public function __construct( $type, $slug, $version, $languages, $wpLanguageDir ) {

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -100,14 +100,14 @@ class Translatable {
 				break;
 
 			default:
-				throw new \Exception( 'Unknown package type' );
+				throw new \Exception( sprintf('Unknown package type "%s"', $this->type) );
 		}
 
 		$body = file_get_contents( $url );
 		$res = json_decode( $body );
 
 		if ( ! isset( $res->translations ) || empty( $res->translations ) ) {
-			throw new \Exception( 'No translations found' );
+			throw new \Exception( sprintf('No translations found for %s', $this->slug) );
 		}
 
 		$translations = [];

--- a/src/Wplang.php
+++ b/src/Wplang.php
@@ -137,7 +137,7 @@ class Wplang implements PluginInterface, EventSubscriberInterface {
 				}
 			}
 		} catch ( \Exception $e ) {
-			$this->io->writeError( $e->getMessage() );
+			$this->io->writeError( '      - ' . $e->getMessage() );
 		}
 
 	}

--- a/src/Wplang.php
+++ b/src/Wplang.php
@@ -3,7 +3,7 @@
 namespace BJ\Wplang;
 
 use Composer\Composer;
-use Composer\Script\Event;
+use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
@@ -50,10 +50,19 @@ class Wplang implements PluginInterface, EventSubscriberInterface {
 		}
 
 		if ( ! empty( $extra['wordpress-language-dir'] ) ) {
-			$this->wpLanguageDir = dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/' . $extra['wordpress-language-dir'];
+			$this->wpLanguageDir = dirname( __DIR__, 4 ) . '/' . $extra['wordpress-language-dir'];
 		}
 	}
 
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        // do nothing
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+        // do nothing
+    }
 
 	/**
 	 * Subscribe to Composer events.
@@ -77,7 +86,7 @@ class Wplang implements PluginInterface, EventSubscriberInterface {
 	 * @param  PackageEvent $event The package event object.
 	 */
 	public function onPackageAction( PackageEvent $event ) {
-        if ( 'update' === $event->getOperation()->getJobType() ) {
+        if ($event->getOperation() instanceof UpdateOperation) {
             $package = $event->getOperation()->getTargetPackage();
         } else {
             $package = $event->getOperation()->getPackage();


### PR DESCRIPTION
This version can be used for installation with Composer 2. Composer 1 can no longer be used with it, so it should become a new minor or major version.