### PR TITLE
Recognise roots/wordpress (Bedrock) as allowed Core package

### DIFF
--- a/src/Wplang.php
+++ b/src/Wplang.php
@@ -115,7 +115,7 @@ class Wplang implements PluginInterface, EventSubscriberInterface {
 					$t = new Translatable( 'theme', $name, $package->getVersion(), $this->languages, $this->wpLanguageDir );
 					break;
 				case 'package':
-					if ( 'johnpbloch' === $provider && 'wordpress' === $name ) {
+					if ( ('johnpbloch' === $provider || 'roots' === $provider) && 'wordpress' === $name ) {
 						$t = new Translatable( 'core', $name, $package->getVersion(), $this->languages, $this->wpLanguageDir );
 					}
 					break;


### PR DESCRIPTION
One of the best ways to setup a wordpress installation with PHP Composer is to use Bedrock (roots/wordpress).

However, wplang currently does not recognise it as WP Core and thus does not download the core language files.

In general, I would argue that whoever is using wplang wants to download core language files, too, but I might be wrong. At least, allowing bedrock versions to download core language files would be very helpful.